### PR TITLE
Suggested fix for #86 - enumerated labels values not generated in stepped pips

### DIFF
--- a/dist/jquery-ui-slider-pips.js
+++ b/dist/jquery-ui-slider-pips.js
@@ -312,7 +312,8 @@
 
                 if ( $.type(options.labels) === "array" ) {
 
-                    label = options.labels[number] || "";
+                    var labelIndex = Math.round( ( number - min ) / options.step );
+                    label = options.labels[labelIndex] || "";
 
                 } else if ( $.type( options.labels ) === "object" ) {
 
@@ -331,7 +332,8 @@
                         // set other labels, but our index should start at -1
                         // because of the first pip.
 
-                        label = options.labels.rest[ number - 1 ] || "";
+                        var labelIndex = Math.round( ( number - min ) / options.step ) - 1;
+                        label = options.labels.rest[labelIndex] || "";
 
                     } else {
 

--- a/src/js/jquery-ui-slider-pips.js
+++ b/src/js/jquery-ui-slider-pips.js
@@ -1,3 +1,6 @@
+/*! jQuery-ui-Slider-Pips - v1.11.1 - 2015-11-30
+* Copyright (c) 2015 Simon Goellner <simey.me@gmail.com>; Licensed MIT */
+
 
 
 (function($) {
@@ -309,7 +312,8 @@
 
                 if ( $.type(options.labels) === "array" ) {
 
-                    label = options.labels[number] || "";
+                    var labelIndex = Math.round( ( number - min ) / options.step );
+                    label = options.labels[labelIndex] || "";
 
                 } else if ( $.type( options.labels ) === "object" ) {
 
@@ -328,7 +332,8 @@
                         // set other labels, but our index should start at -1
                         // because of the first pip.
 
-                        label = options.labels.rest[ number - 1 ] || "";
+                        var labelIndex = Math.round( ( number - min ) / options.step ) - 1;
+                        label = options.labels.rest[labelIndex] || "";
 
                     } else {
 


### PR DESCRIPTION
As per original commit (fcbfa2e) message:

Add label index calculation to assignment of label in `createPip()` for both pips `options.labels` arrays and (speculatively) pips `options.labels.rest`. Closes #86.

_EDIT: original commit edited file in wrong directory, so please free to cherrypick only second commit_