### PR TITLE
Add MIT LICENSE.txt file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2014 Simon Goellner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This repository already declares MIT licensing in `package.json`, but it does not currently include an explicit `LICENSE.txt` file.

Adding the standard MIT license file helps:
- make the licensing terms immediately visible to developers and organizations,
- improve compatibility with automated license scanners and package auditing tools,
- clarify redistribution and modification rights,
- and explicitly document that developers may legally fork, modify, maintain, and redistribute their own versions of the project under the MIT terms.

This is especially useful for community-maintained forks or long-term maintenance scenarios where having a clearly defined license file is important for legal and organizational compliance.